### PR TITLE
修正使用者更新資訊時密碼為空會出錯，新增使用者升等API，新增使用者是否為Zookeeper回傳

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 use App\Eagle;
 use App\User;
 
@@ -61,4 +62,58 @@ class AdminController extends Controller
             ]
         ], 200);
     }
+
+    /**
+     * 升等使用者
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function upgrade(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'target_mail' => 'required|string|email|max:255'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => [
+                    'status' => 422,
+                    'message' => $validator->messages()
+                ]
+            ], 422);
+        }
+
+        $token = $request->header('Authorization');
+        $user = User::where('api_token', $token)->first();
+        if (is_null($user)) {
+            return response()->json([
+                'error' => [
+                    'status' => 404,
+                    'message' => 'User Not Found'
+                ]
+            ], 404);
+        }
+
+        $object = User::where('email', $request->target_mail)->first();
+        if (is_null($object)) {
+            return response()->json([
+                'error' => [
+                    'status' => 404,
+                    'message' => 'Target Not Found'
+                ]
+            ], 404);
+        }
+        
+        $object->is_admin = '1';
+        $object->save();
+
+        return response()->json([
+            'Success' => [
+                'status' => 200,
+                'message' => 'Upgrade succeed!',
+            ]
+        ], 200);
+    }
+
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -83,7 +83,9 @@ class UserController extends Controller
         }
 
         $user->name = $request->name ?? $user->name;
-        $user->password = bcrypt($request->password) ?? $user->password;
+        if (!is_null($request->password)) {
+            $user->password = bcrypt($request->password);
+        }
         $user->save();
         return response()->json([
             'Success' => [

--- a/app/User.php
+++ b/app/User.php
@@ -25,7 +25,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $hidden = [
-        'password', 'id', 'is_admin',  'created_at', 'updated_at', 'api_token', 'pivot',
+        'password', 'id', 'created_at', 'updated_at', 'api_token', 'pivot',
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -60,4 +60,6 @@ Route::group(['prefix' => 'zookeeper',  'middleware' => 'isadmin.api'], function
     Route::get('/users', 'AdminController@users');
     //列出所有老鷹
     Route::get('/eagles', 'AdminController@eagles');
+    //更改使用者權限
+    Route::put('/users', 'AdminController@upgrade');
 });


### PR DESCRIPTION
使用者更新資訊時，由於加密null仍會有值，因此會出錯
使用者可以透過API升等為zookeeper，但這個api只有zookeeper可以用
回傳使用者資訊時會同時回傳是否為zookeeper