### PR TITLE
增修兩支顯示羽毛的API，修改Get回傳的格式

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -28,12 +28,7 @@ class AdminController extends Controller
             ], 404);
         }
 
-        return response()->json([
-            'Success' => [
-                'status' => 200,
-                'users' => User::all()
-            ]
-        ], 200);
+        return (User::all());
     }
 
     /**
@@ -55,12 +50,7 @@ class AdminController extends Controller
             ], 404);
         }
 
-        return response()->json([
-            'Success' => [
-                'status' => 200,
-                'eagles' => Eagle::all()->makeHidden(['job_token'])
-            ]
-        ], 200);
+        return (Eagle::all()->makeHidden(['job_token']));
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -27,13 +27,8 @@ class UserController extends Controller
             ], 404);
         }
 
-        return response()->json([
-            'Success' => [
-                'status' => 200,
-                'name' => $user->name,
-                'is_admin' => $user->is_admin
-            ]
-        ], 200);
+        return (array('name' => $user->name,
+                      'is_admin' => $user->is_admin));
     }
 
     /**

--- a/app/Http/Controllers/UserEagleController.php
+++ b/app/Http/Controllers/UserEagleController.php
@@ -49,12 +49,7 @@ class UserEagleController extends Controller
 
         $viewer = $eagle->users;
 
-        return response()->json([
-            'Success' => [
-                'status' => 200,
-                'viewers' => $viewer
-            ]
-        ], 200);
+        return ($viewer);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,8 +42,10 @@ Route::middleware('agriweather.api')->group(function () {
     Route::post('/eagles/{eagleId}', 'EagleController@update');
     // 刪除老鷹
     Route::delete('/eagles/{eagleId}', 'EagleController@delete');
-    // 要最後數支羽毛，預設1支
+    // 要最後數支羽毛，預設1支，可跳過，預設跳過10支
     Route::get('/eagles/{eagleId}/feathers', 'EagleController@feathers');
+    // 要多隻老鷹的最後10支羽毛
+    Route::get('/eagles/feathers', 'EagleController@batchFeathers');
     // 列出觀察者
     Route::get('/eagles/{eagleId}/viewers', 'UserEagleController@viewers');
     // 新增觀察者


### PR DESCRIPTION
修改原始回傳羽毛的API，新增skip的request input，使得可以略過幾支羽毛不計
路徑為：/eagles/{eagleID}/feathers?range={回傳幾支}&skip={跳過幾支}
新增批次回傳羽毛的API，藉由前端回傳的老鷹list撈取每隻老鷹的10支羽毛
路徑為：/eagles/feathers?eagles={老鷹id1},{老鷹id2},{老鷹id3},.......

修改Get回傳內容的格式，去除Success以及狀態碼200重複出現的問題
- 使用者資料
- 老鷹的觀察者列表
- 老鷹列表
- 可以跳過的羽毛
- 批次回傳羽毛
- 列出所有使用者
- 列出所有老鷹